### PR TITLE
Make valid page links use link color, not missing link color

### DIFF
--- a/dracula.css
+++ b/dracula.css
@@ -187,7 +187,7 @@ html {
   --editor-naked-url-color: var(--link-color);
   --editor-link-color: var(--link-color);
   --editor-link-url-color: var(--link-color);
-  --editor-wiki-link-page-color: var(--text-a);
+  --editor-wiki-link-page-color: var(--link-color);
   --editor-wiki-link-page-background-color: transparent;
   --editor-wiki-link-page-missing-color: var(--link-missing-color);
   --editor-link-meta-color: var(--meta-subtle-color);


### PR DESCRIPTION
I noticed a problem when using this theme: my links to missing/"aspiring" pages were the same color as my links to valid pages, despite the original theme having separate coloring set up for these two cases. It seems the problem was that `editor-wiki-link-page-color` used `--text-a`, which is the same value assigned to `--link-missing-color`. So I swapped that out for `--link-color`, which I feel was probably the *intended* use of that variable?

PS: Great theme, thanks for your work setting this up!